### PR TITLE
Fixed crash when Console cursor properties are not available

### DIFF
--- a/BSA Browser CLI/Program.cs
+++ b/BSA Browser CLI/Program.cs
@@ -185,17 +185,31 @@ namespace BSA_Browser_CLI
                 {
                     int count = 0;
                     int total = archive.Files.Count(x => Filter(x.FullPath));
-                    int line = Console.CursorTop;
-                    int prevLength = 0;
+					int line = -1;
+					int prevLength = 0;
+
+					// Some Console properties might not be available in certain situations, 
+					// e.g. when redirecting stdout. To prevent crashing, setting the cursor position should only
+					// be done if there actually is a cursor to be set.
+					try {
+						line = Console.CursorTop;
+					}
+					catch (IOException) {}
 
                     foreach (var entry in archive.Files)
                     {
                         if (!Filter(entry.FullPath))
                             continue;
 
-                        Console.SetCursorPosition(0, line);
-                        string output = $"Extracting: {++count}/{total} - {entry.FullPath}";
-                        Console.Write(output.PadRight(prevLength));
+						string output = $"Extracting: {++count}/{total} - {entry.FullPath}".PadRight(prevLength);
+
+						if (line > -1) {
+							Console.SetCursorPosition(0, line);
+							Console.Write(output);
+						}
+						else {
+							Console.WriteLine(output);
+						}
                         prevLength = output.Length;
 
                         entry.Extract(destination, true);


### PR DESCRIPTION
Console.SetCursorPosition and Console.CursorTop are not guaranteed to
be available. E.g. when redirecting stdout, the program simply crashed
with an IOException.

In case the cursor cannot be accessed, the output is now being printed without cursor position based formatting.